### PR TITLE
Fix typo in notify_on attribute

### DIFF
--- a/core/sofortLibAbstract.inc.php
+++ b/core/sofortLibAbstract.inc.php
@@ -570,7 +570,7 @@ abstract class SofortLibAbstract {
 				if (in_array($notifyStatus, $notifyOnDefault)) $notifyOnArray[] = $notifyStatus;
 			}
 
-			$notifyOn = array('notifyOn' => implode(',', $notifyOnArray));
+			$notifyOn = array('notify_on' => implode(',', $notifyOnArray));
 		}
 
 		if (!$notifyOn) {


### PR DESCRIPTION
The attribute 'notifyOn' is wrong it should by 'notify_on' according to https://integration.sofort.com/integrationCenter-ger-DE/content/view/full/2513/#h3-3-2